### PR TITLE
pkg/archive: sync files before issuing the fadvise syscall

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -513,6 +513,17 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			file.Close()
 			return err
 		}
+
+		if err := file.Sync(); err != nil {
+			file.Close()
+			return err
+		}
+
+		if err := unix.Fadvise(int(file.Fd()), 0, 0, unix.FADV_DONTNEED); err != nil {
+			file.Close()
+			return err
+		}
+
 		file.Close()
 
 	case tar.TypeBlock, tar.TypeChar:
@@ -622,19 +633,6 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		if err := system.LUtimesNano(path, ts); err != nil && err != system.ErrNotSupportedPlatform {
 			return err
 		}
-	}
-
-	if hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA {
-		file, err := os.Open(path)
-		if err != nil {
-			file.Close()
-			return err
-		}
-		if err := unix.Fadvise(int(file.Fd()), 0, 0, unix.FADV_DONTNEED); err != nil {
-			file.Close()
-			return err
-		}
-		file.Close()
 	}
 
 	return nil


### PR DESCRIPTION
Linux ignores fadvise for dirty pages so we need to make sure we sync to
have them marked as clean before discarding

Ref: https://github.com/torvalds/linux/blob/v4.13/mm/truncate.c#L489-L493
