### PR TITLE
Issue template should refer to balena throughout

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -49,13 +49,13 @@ Briefly describe the problem you are having in a few paragraphs.
 
 **Additional information you deem important (e.g. issue happens only occasionally):**
 
-**Output of `docker version`:**
+**Output of `balena version`:**
 
 ```
 (paste your output here)
 ```
 
-**Output of `docker info`:**
+**Output of `balena info`:**
 
 ```
 (paste your output here)


### PR DESCRIPTION
balena inherited the issue template from Docker; it should customize it. This patch notes the issue and fixes part of it.