### PR TITLE
container: remove extraneous lock leading to deadlocks

### DIFF
--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -96,8 +96,6 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 	}
 
 	defer func() {
-		container.Lock()
-		defer container.Unlock()
 		if err != nil {
 			container.Name = oldName
 			container.NetworkSettings.IsAnonymousEndpoint = oldIsAnonymousEndpoint


### PR DESCRIPTION
defers are called in the opposite way that they were declared. The container is already being locked in the function
