### PR TITLE
vendor: update btrfs dependency

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -104,7 +104,7 @@ google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 
 # containerd
 github.com/containerd/containerd 3325981309990c69cb2869a45709fbbf1afa2401 https://github.com/resin-os/balena-containerd # v1.0.0
-github.com/containerd/btrfs cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3
+github.com/containerd/btrfs 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244
 github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
 github.com/containerd/continuity 35d55c5e8dd23b32037d56cf97174aff3efdfa83
 github.com/containerd/cgroups 29da22c6171a4316169f9205ab6c49f59b5b852f

--- a/vendor/github.com/containerd/btrfs/README.md
+++ b/vendor/github.com/containerd/btrfs/README.md
@@ -16,3 +16,23 @@ is missing, please don't hesitate to submit a PR.
 Note that due to struct alignment issues, this isn't yet fully native.
 Preferrably, this could be resolved, so contributions in this direction are
 greatly appreciated.
+
+## Applying License Header to New Files
+
+If you submit a contribution that adds a new file, please add the license
+header. You can do so manually or use the `ltag` tool:
+
+
+```console
+$ go get github.com/kunalkushwaha/ltag
+$ ltag -t ./license-templates
+```
+
+The above will add the appropriate licenses to Go files. New templates will
+need to be added if other kinds of files are added. Please consult the
+documentation at https://github.com/
+
+# License
+
+The copyright to this repository is held by the The containerd Authors and the
+codebase is released under the [Apache 2.0 license](LICENSE).

--- a/vendor/github.com/containerd/btrfs/btrfs.go
+++ b/vendor/github.com/containerd/btrfs/btrfs.go
@@ -1,3 +1,18 @@
+/*
+  Copyright The containerd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package btrfs
 
 import "sort"
@@ -6,10 +21,6 @@ import "sort"
 #include <stddef.h>
 #include <btrfs/ioctl.h>
 #include "btrfs.h"
-
-// Required because Go has struct casting rules for negative numbers
-const __u64 u64_BTRFS_LAST_FREE_OBJECTID = (__u64)BTRFS_LAST_FREE_OBJECTID;
-const __u64 negative_one = (__u64)-1;
 
 static char* get_name_btrfs_ioctl_vol_args_v2(struct btrfs_ioctl_vol_args_v2* btrfs_struct) {
 	return btrfs_struct->name;
@@ -81,13 +92,13 @@ func SubvolInfo(path string) (info Info, err error) {
 	}
 
 	if info, ok := subvolsByID[id]; ok {
-		return info, nil
+		return *info, nil
 	}
 
 	return info, errors.Errorf("%q not found", path)
 }
 
-func subvolMap(path string) (map[uint64]Info, error) {
+func subvolMap(path string) (map[uint64]*Info, error) {
 	fp, err := openSubvolDir(path)
 	if err != nil {
 		return nil, err
@@ -100,11 +111,11 @@ func subvolMap(path string) (map[uint64]Info, error) {
 	args.key.min_type = C.BTRFS_ROOT_ITEM_KEY
 	args.key.max_type = C.BTRFS_ROOT_BACKREF_KEY
 	args.key.min_objectid = C.BTRFS_FS_TREE_OBJECTID
-	args.key.max_objectid = C.u64_BTRFS_LAST_FREE_OBJECTID
-	args.key.max_offset = C.negative_one
-	args.key.max_transid = C.negative_one
+	args.key.max_objectid = C.BTRFS_LAST_FREE_OBJECTID
+	args.key.max_offset = ^C.__u64(0)
+	args.key.max_transid = ^C.__u64(0)
 
-	subvolsByID := map[uint64]Info{}
+	subvolsByID := make(map[uint64]*Info)
 
 	for {
 		args.key.nr_items = 4096
@@ -127,6 +138,9 @@ func subvolMap(path string) (map[uint64]Info, error) {
 			buf = buf[shSize:]
 
 			info := subvolsByID[uint64(sh.objectid)]
+			if info == nil {
+				info = &Info{}
+			}
 			info.ID = uint64(sh.objectid)
 
 			if sh._type == C.BTRFS_ROOT_BACKREF_KEY {
@@ -233,7 +247,7 @@ func SubvolList(path string) ([]Info, error) {
 
 	subvols := make([]Info, 0, len(subvolsByID))
 	for _, sv := range subvolsByID {
-		subvols = append(subvols, sv)
+		subvols = append(subvols, *sv)
 	}
 
 	sort.Sort(infosByID(subvols))

--- a/vendor/github.com/containerd/btrfs/doc.go
+++ b/vendor/github.com/containerd/btrfs/doc.go
@@ -13,14 +13,5 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+// Package btrfs provides bindings for working with btrfs partitions from Go.
 package btrfs
-
-import "syscall"
-
-func ioctl(fd, request, args uintptr) error {
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, request, args)
-	if errno != 0 {
-		return errno
-	}
-	return nil
-}

--- a/vendor/github.com/containerd/btrfs/helpers.go
+++ b/vendor/github.com/containerd/btrfs/helpers.go
@@ -1,3 +1,18 @@
+/*
+  Copyright The containerd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package btrfs
 
 /*

--- a/vendor/github.com/containerd/btrfs/info.go
+++ b/vendor/github.com/containerd/btrfs/info.go
@@ -1,3 +1,18 @@
+/*
+  Copyright The containerd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package btrfs
 
 // Info describes metadata about a btrfs subvolume.


### PR DESCRIPTION
When building with BTRFS enabled, currently running into an issue:
```
---> Making bundle: binary-balena (in bundles/binary-balena)
Building: bundles/binary-balena/balena-dev
# github.com/docker/docker/vendor/github.com/containerd/btrfs
.gopath/src/github.com/docker/docker/vendor/github.com/containerd/btrfs/btrfs.go:103: constant 18446744073709551616 overflows _Ctype_ulonglong
.gopath/src/github.com/docker/docker/vendor/github.com/containerd/btrfs/btrfs.go:104: constant 18446744073709551616 overflows _Ctype_ulonglong
.gopath/src/github.com/docker/docker/vendor/github.com/containerd/btrfs/btrfs.go:105: constant 18446744073709551616 overflows _Ctype_ulonglong
```
Upstream seems to have fixed this very issue in https://github.com/containerd/containerd/pull/2190 and that same vendoring is done in the PR.

**- How to verify it**
Run build with this PR, that successfully finished.

**- Description for the changelog**
Provides updates for licensing and a build problem.

**- A picture of a cute animal (not mandatory but encouraged)**
![papageitaucher_fratercula_arctica](https://user-images.githubusercontent.com/38863/41127014-5fa519b4-6aa1-11e8-9bd5-59c467810423.jpg)

Signed-off-by: Gergely Imreh <imrehg@gmail.com>
