### PR TITLE
pkg/stringid: don't bother seeding math/random with crypto grade seed

### DIFF
--- a/pkg/stringid/stringid.go
+++ b/pkg/stringid/stringid.go
@@ -6,8 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math"
-	"math/big"
 	"math/rand"
 	"regexp"
 	"strconv"
@@ -79,17 +77,7 @@ func ValidateID(id string) error {
 }
 
 func init() {
-	// safely set the seed globally so we generate random ids. Tries to use a
-	// crypto seed before falling back to time.
-	var seed int64
-	if cryptoseed, err := cryptorand.Int(cryptorand.Reader, big.NewInt(math.MaxInt64)); err != nil {
-		// This should not happen, but worst-case fallback to time-based seed.
-		seed = time.Now().UnixNano()
-	} else {
-		seed = cryptoseed.Int64()
-	}
-
-	rand.Seed(seed)
+	rand.Seed(time.Now().UnixNano())
 }
 
 type readerFunc func(p []byte) (int, error)


### PR DESCRIPTION
Seeding the math/random RNG with a crypto grade seed slows down startup
on embedded devices that don't have enough entropy during early boot.

Furthermore math/rand is seeded by a lot of other packages with
non-crypto grade seeds which makes it a last write wins situation.

Since math/rand is only used in the GenerateNonCryptoID function, we
make it always use the current time as a seed to avoid startup delays.

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/resin-os/balena/blob/17.06-resin/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For general information on Balena visit https://www.balena.io

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

