### PR TITLE
mobynit: Add support for mounting rootfs from a custom path

### DIFF
--- a/cmd/mobynit/main.go
+++ b/cmd/mobynit/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -21,19 +23,10 @@ const (
 	PIVOT_PATH = "/mnt/sysroot/active"
 )
 
-func mountContainer(containerID, graphDriver string) string {
-	if err := os.MkdirAll("/dev/shm", os.ModePerm); err != nil {
-		log.Fatal("creating /dev/shm failed:", err)
-	}
-
-	if err := unix.Mount("shm", "/dev/shm", "tmpfs", 0, ""); err != nil {
-		log.Fatal("error mounting /dev/shm:", err)
-	}
-	defer unix.Unmount("/dev/shm", unix.MNT_DETACH)
-
+func mountContainer(layer_root, containerID, graphDriver string) string {
 	ls, err := layer.NewStoreFromOptions(layer.StoreOptions{
-		StorePath:                 LAYER_ROOT,
-		MetadataStorePathTemplate: filepath.Join(LAYER_ROOT, "image", "%s", "layerdb"),
+		StorePath:                 layer_root,
+		MetadataStorePathTemplate: filepath.Join(layer_root, "image", "%s", "layerdb"),
 		IDMappings:                &idtools.IDMappings{},
 		GraphDriver:               graphDriver,
 		OS:                        "linux",
@@ -56,6 +49,22 @@ func mountContainer(containerID, graphDriver string) string {
 	if err := unix.Mount("", newRootPath, "", unix.MS_REMOUNT, ""); err != nil {
 		log.Fatal("error remounting container as read/write:", err)
 	}
+
+	return newRootPath
+}
+
+func prepareForPivot(containerID, graphDriver string) string {
+	if err := os.MkdirAll("/dev/shm", os.ModePerm); err != nil {
+		log.Fatal("creating /dev/shm failed:", err)
+	}
+
+	if err := unix.Mount("shm", "/dev/shm", "tmpfs", 0, ""); err != nil {
+		log.Fatal("error mounting /dev/shm:", err)
+	}
+	defer unix.Unmount("/dev/shm", unix.MNT_DETACH)
+
+	newRootPath := mountContainer(filepath.Join("", LAYER_ROOT), containerID, graphDriver)
+
 	defer unix.Mount("", newRootPath, "", unix.MS_REMOUNT|unix.MS_RDONLY, "")
 
 	if err := os.MkdirAll(filepath.Join(newRootPath, PIVOT_PATH), os.ModePerm); err != nil {
@@ -65,46 +74,67 @@ func mountContainer(containerID, graphDriver string) string {
 	return newRootPath
 }
 
-func main() {
-	// Any mounts done by initrd will be transfered in the new root
-	mounts, err := mount.GetMounts()
-
-	rawGraphDriver, err := ioutil.ReadFile("/current/boot/storage-driver")
+func getStorageDriverAndContainerID(sysroot string) (string, string) {
+	rawGraphDriver, err := ioutil.ReadFile(filepath.Join(sysroot, "/current/boot/storage-driver"))
 	if err != nil {
 		log.Fatal("could not get storage driver:", err)
 	}
 	graphDriver := strings.TrimSpace(string(rawGraphDriver))
 
-	current, err := os.Readlink("/current")
+	current, err := os.Readlink(filepath.Join(sysroot, "/current"))
 	if err != nil {
 		log.Fatal("could not get container ID:", err)
 	}
 	containerID := filepath.Base(current)
 
-	if err := unix.Mount("", "/", "", unix.MS_REMOUNT, ""); err != nil {
-		log.Fatal("error remounting root as read/write:", err)
+	return graphDriver, containerID
+}
+
+func main() {
+	sysrootPtr := flag.String("sysroot", "", "root of partition e.g. /mnt/sysroot/inactive. Mount destination is returned in stdout")
+	flag.Parse()
+
+	// Any mounts done by initrd will be transfered in the new root
+	mounts, err := mount.GetMounts()
+	if err != nil {
+		log.Fatal("could not get mounts:", err)
 	}
 
-	newRoot := mountContainer(containerID, graphDriver)
+	var graphDriver, containerID string
 
-	for _, mount := range mounts {
-		if mount.Mountpoint == "/" {
-			continue
+	// If a custom sysroot is passed, use it instead of LAYER_ROOT
+	if *sysrootPtr != "" {
+		graphDriver, containerID = getStorageDriverAndContainerID(*sysrootPtr)
+		newRootPath := mountContainer(filepath.Join(*sysrootPtr, LAYER_ROOT), containerID, graphDriver)
+		fmt.Print(newRootPath)
+	} else {
+		graphDriver, containerID = getStorageDriverAndContainerID("")
+
+		if err := unix.Mount("", "/", "", unix.MS_REMOUNT, ""); err != nil {
+			log.Fatal("error remounting root as read/write:", err)
 		}
-		if err := unix.Mount(mount.Mountpoint, filepath.Join(newRoot, mount.Mountpoint), "", unix.MS_MOVE, ""); err != nil {
-			log.Println("could not move mountpoint:", mount.Mountpoint, err)
+
+		newRoot := prepareForPivot(containerID, graphDriver)
+
+		for _, mount := range mounts {
+			if mount.Mountpoint == "/" {
+				continue
+			}
+			if err := unix.Mount(mount.Mountpoint, filepath.Join(newRoot, mount.Mountpoint), "", unix.MS_MOVE, ""); err != nil {
+				log.Println("could not move mountpoint:", mount.Mountpoint, err)
+			}
 		}
-	}
 
-	if err := syscall.PivotRoot(newRoot, filepath.Join(newRoot, PIVOT_PATH)); err != nil {
-		log.Fatal("error while pivoting root:", err)
-	}
+		if err := syscall.PivotRoot(newRoot, filepath.Join(newRoot, PIVOT_PATH)); err != nil {
+			log.Fatal("error while pivoting root:", err)
+		}
 
-	if err := unix.Chdir("/"); err != nil {
-		log.Fatal(err)
-	}
+		if err := unix.Chdir("/"); err != nil {
+			log.Fatal(err)
+		}
 
-	if err := syscall.Exec("/sbin/init", os.Args, os.Environ()); err != nil {
-		log.Fatal("error executing init:", err)
+		if err := syscall.Exec("/sbin/init", os.Args, os.Environ()); err != nil {
+			log.Fatal("error executing init:", err)
+		}
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/resin-os/balena/blob/17.06-resin/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For general information on Balena visit https://www.balena.io

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a few patches to add support for mounting rootfs from a custom path

**- How I did it**
By copying existing code in mobynit and modifying it.

**- How to verify it**
I tested it on a raspberry pi3 running resinOS
```
root@resin:/tmp# ./mobynit -layer-root /mnt/sysroot/inactive/
/mnt/sysroot/inactive/balena/aufs/mnt/572e07e5a91cbb6d43593c5cc56d20a7b0d9438ca9841645932cad5a94e3280broot@resin:/tmp# 
root@resin:/tmp# ls /mnt/sysroot/inactive/balena/aufs/mnt/572e07e5a91cbb6d43593c5cc56d20a7b0d9438ca9841645932cad5a94e3280b    
bin   dev  home  linuxrc  mnt   quirks      resin-data           run   srv  tmp  var
boot  etc  lib   media    proc  resin-boot  resinos.fingerprint  sbin  sys  usr
root@resin:/tmp# 
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
mobynit: Add support for mounting rootfs from a custom path.

**- A picture of a cute animal (not mandatory but encouraged)**

