### PR TITLE
version: fix version strings reported in the cli

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ esac
 
 version=$(git describe --tags --always)
 
-AUTO_GOPATH=1 GOMAXPROCS=1 DOCKER_LDFLAGS="-s" ./hack/make.sh binary-balena
+AUTO_GOPATH=1 GOMAXPROCS=1 DOCKER_LDFLAGS="-s" VERSION="$version" ./hack/make.sh binary-balena
 
 src="bundles/latest/binary-balena"
 dst="balena"

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -91,6 +91,11 @@ else
 	echo >&2 '  future accountability in diagnosing build issues.  Thanks!'
 	exit 1
 fi
+LDFLAGS="\
+    -X \"github.com/docker/docker/vendor/github.com/docker/cli/cli.GitCommit=${GITCOMMIT}\" \
+    -X \"github.com/docker/docker/vendor/github.com/docker/cli/cli.BuildTime=${BUILDTIME}\" \
+    -X \"github.com/docker/docker/vendor/github.com/docker/cli/cli.Version=${VERSION}\" \
+"
 
 if [ "$AUTO_GOPATH" ]; then
 	rm -rf .gopath
@@ -132,7 +137,7 @@ fi
 
 IAMSTATIC='true'
 if [ -z "$DOCKER_DEBUG" ]; then
-	LDFLAGS='-w'
+	LDFLAGS="$LDFLAGS -w"
 fi
 
 LDFLAGS_STATIC=''


### PR DESCRIPTION
**- What I did**

Updated the build scripts to correctly set the CLI and server version information

**- How I did it**

Setting the right environment variables and build time flags for the go compiler, to match the requirements of the build script.

**- How to verify it**

Before this PR the version check results are:

```
$ ./balena -v     
balena version unknown-version, build unknown-commit

$ ./balena version
Client:
 Version:	unknown-version
 API version:	1.35
 Go version:	go1.10.3
 Git commit:	unknown-commit
 Built:	unknown-buildtime
 OS/Arch:	linux/amd64
 Experimental:	false
 Orchestrator:	swarm

Server:
 Engine:
  Version:	dev
  API version:	1.35 (minimum version 1.12)
  Go version:	go1.10.3
  Git commit:	2fe3ad156
  Built:	Tue Aug 28 12:10:00 2018
  OS/Arch:	linux/amd64
  Experimental:	false
```

Build the PR, and running the server, run the CLI version check:

```
$ ./balena -v
balena version v17.12.0-2-gc87589c33, build c87589c33

$ ./balena version
Client:
 Version:	v17.12.0-2-gc87589c33
 API version:	1.35
 Go version:	go1.10.3
 Git commit:	c87589c33
 Built:	Tue Aug 28 12:07:35 2018
 OS/Arch:	linux/amd64
 Experimental:	false
 Orchestrator:	swarm

Server:
 Engine:
  Version:	v17.12.0-2-gc87589c33
  API version:	1.35 (minimum version 1.12)
  Go version:	go1.10.3
  Git commit:	c87589c33
  Built:	Tue Aug 28 12:07:35 2018
  OS/Arch:	linux/amd64
  Experimental:	false
```

**- Description for the changelog**

Fixes for data reported by balena version checks

Fixes #74 

**- A picture of a cute animal (not mandatory but encouraged)**

![baby_seal](https://user-images.githubusercontent.com/38863/44722797-22ddae00-aac6-11e8-8985-fd71b7bc2928.jpg)


[photo credit](https://www.catersnews.com/stories/animals/seal-of-approval-adorable-seal-pup-waves-at-photographer/)