### PR TITLE
delta: use chain ids to decide whether to skip a layer

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -412,17 +412,26 @@ func (daemon *Daemon) DeltaCreate(deltaSrc, deltaDest string, outStream io.Write
 			layerData io.Reader
 			platform layer.OS
 		)
+
 		commonLayer := false
+		dstRootFS := *dstImg.RootFS
+		dstRootFS.DiffIDs = dstRootFS.DiffIDs[:i+1]
+
+		if i < len(srcImg.RootFS.DiffIDs) {
+			srcRootFS := *srcImg.RootFS
+			srcRootFS.DiffIDs = srcRootFS.DiffIDs[:i+1]
+
+			if srcRootFS.ChainID() == dstRootFS.ChainID() {
+				commonLayer = true
+			}
+		}
 
 		// We're only interested in layers that are different. Push empty
 		// layers for common layers
-		if i < len(srcImg.RootFS.DiffIDs) && srcImg.RootFS.DiffIDs[i] == diffID {
-			commonLayer = true
+		if commonLayer {
 			layerData, _ = layer.EmptyLayer.TarStream()
 			platform = layer.EmptyLayer.OS()
 		} else {
-			dstRootFS := *dstImg.RootFS
-			dstRootFS.DiffIDs = dstRootFS.DiffIDs[:i+1]
 
 			l, err := ls.Get(dstRootFS.ChainID())
 			if err != nil {


### PR DESCRIPTION
With the previous code if two layers had identical contents (and diff
ids) but different parents (and different chain ids) they would be
considered common and skipped.

However the pulling code uses the chain id to decide whether it should
pull a layer so a delta created under these conditions was leading to
the pulling code trying to apply a non-existent delta.

This is fixed by using the same logic with chain ids in the generation
phase.
