### PR TITLE
Skip integration tests that are pending balenaEngine compatibility investigation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run -e DOCKER_GITCOMMIT=foo --privileged docker hack/make.sh test-unit test-integration test-docker-py
+# docker run -e DOCKER_GITCOMMIT=foo --privileged docker hack/make.sh test-integration test-docker-py
 #
 # # Publish a release:
 # docker run --privileged \

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4141,6 +4141,9 @@ func (s *DockerSuite) TestBuildRUNErrMsg(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedBuild(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := s.setupTrustedImage(c, "trusted-build")
 	dockerFile := fmt.Sprintf(`
   FROM %s
@@ -4176,6 +4179,9 @@ func (s *DockerTrustSuite) TestTrustedBuildUntrustedTag(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestBuildContextDirIsSymlink(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 	tempDir, err := ioutil.TempDir("", "test-build-dir-is-symlink-")
 	c.Assert(err, check.IsNil)
@@ -4211,6 +4217,9 @@ func (s *DockerTrustSuite) TestBuildContextDirIsSymlink(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedBuildTagFromReleasesRole(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, NotaryHosting)
 
 	latestTag := s.setupTrustedImage(c, "trusted-build-releases-role")
@@ -4242,6 +4251,9 @@ func (s *DockerTrustSuite) TestTrustedBuildTagFromReleasesRole(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedBuildTagIgnoresOtherDelegationRoles(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, NotaryHosting)
 
 	latestTag := s.setupTrustedImage(c, "trusted-build-releases-role")
@@ -6109,6 +6121,9 @@ func (s *DockerSuite) TestBuildFromPreviousBlock(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestCopyFromTrustedBuild(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	img1 := s.setupTrustedImage(c, "trusted-build1")
 	img2 := s.setupTrustedImage(c, "trusted-build2")
 	dockerFile := fmt.Sprintf(`

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -609,6 +609,9 @@ func (s *DockerSchema1RegistrySuite) TestPullFailsWithAlteredManifest(c *check.C
 // we have modified a layer blob and its digest cannot be verified.
 // This is the schema2 version of the test.
 func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 	manifestDigest, err := setupImage(c)
 	c.Assert(err, checker.IsNil)
@@ -652,6 +655,9 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
 // we have modified a layer blob and its digest cannot be verified.
 // This is the schema1 version of the test.
 func (s *DockerSchema1RegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 	manifestDigest, err := setupImage(c)
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -293,6 +293,9 @@ func (s *DockerSuite) TestCreateByImageID(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedCreate(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := s.setupTrustedImage(c, "trusted-create")
 
 	// Try create
@@ -319,6 +322,9 @@ func (s *DockerTrustSuite) TestUntrustedCreate(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedIsolatedCreate(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := s.setupTrustedImage(c, "trusted-isolated-create")
 
 	// Try create
@@ -329,6 +335,9 @@ func (s *DockerTrustSuite) TestTrustedIsolatedCreate(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedCreateFromBadTrustServer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := fmt.Sprintf("%v/dockerclievilcreate/trusted:latest", privateRegistryURL)
 	evilLocalConfigDir, err := ioutil.TempDir("", "evilcreate-local-config-dir")
 	c.Assert(err, check.IsNil)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -56,6 +56,9 @@ func (s *DockerDaemonSuite) TestLegacyDaemonCommand(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithRunningContainersPorts(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	cli.Docker(
@@ -90,6 +93,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithRunningContainersPorts(c *check
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithVolumesRefs(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	if out, err := s.d.Cmd("run", "--name", "volrestarttest1", "-v", "/foo", "busybox"); err != nil {
@@ -116,6 +122,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithVolumesRefs(c *check.C) {
 
 // #11008
 func (s *DockerDaemonSuite) TestDaemonRestartUnlessStopped(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "-d", "--name", "top1", "--restart", "always", "busybox:latest", "top")
@@ -166,6 +175,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartUnlessStopped(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartOnFailure(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "-d", "--name", "test1", "--restart", "on-failure:3", "busybox:latest", "false")
@@ -195,6 +207,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartOnFailure(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonStartIptablesFalse(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c, "--iptables=false")
 }
 
@@ -273,6 +288,9 @@ func convertBasesize(basesizeBytes int64) (int64, error) {
 // no longer has an IP associated, we should gracefully handle that case and associate
 // an IP with it rather than fail daemon start
 func (s *DockerDaemonSuite) TestDaemonStartBridgeWithoutIPAssociation(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// rather than depending on brctl commands to verify balena0 is created and up
 	// let's start the daemon and stop it, and then make a modification to run the
 	// actual test
@@ -289,6 +307,9 @@ func (s *DockerDaemonSuite) TestDaemonStartBridgeWithoutIPAssociation(c *check.C
 }
 
 func (s *DockerDaemonSuite) TestDaemonIptablesClean(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	if out, err := s.d.Cmd("run", "-d", "--name", "top", "-p", "80", "busybox:latest", "top"); err != nil {
@@ -307,6 +328,9 @@ func (s *DockerDaemonSuite) TestDaemonIptablesClean(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonIptablesCreate(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	if out, err := s.d.Cmd("run", "-d", "--name", "top", "--restart=always", "-p", "80", "busybox:latest", "top"); err != nil {
@@ -412,6 +436,9 @@ func (s *DockerDaemonSuite) TestDaemonIPv6Enabled(c *check.C) {
 // TestDaemonIPv6FixedCIDR checks that when the daemon is started with --ipv6=true and a fixed CIDR
 // that running containers are given a link-local and global IPv6 address
 func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDR(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// IPv6 setup is messing with local bridge address.
 	testRequires(c, SameHostDaemon)
 	// Delete the balena0 bridge if its left around from previous daemon. It has to be recreated with
@@ -440,6 +467,9 @@ func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDR(c *check.C) {
 // TestDaemonIPv6FixedCIDRAndMac checks that when the daemon is started with ipv6 fixed CIDR
 // the running containers are given an IPv6 address derived from the MAC address and the ipv6 fixed CIDR
 func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDRAndMac(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// IPv6 setup is messing with local bridge address.
 	testRequires(c, SameHostDaemon)
 	// Delete the balena0 bridge if its left around from previous daemon. It has to be recreated with
@@ -459,6 +489,9 @@ func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDRAndMac(c *check.C) {
 // TestDaemonIPv6HostMode checks that when the running a container with
 // network=host the host ipv6 addresses are not removed
 func (s *DockerDaemonSuite) TestDaemonIPv6HostMode(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon)
 	deleteInterface(c, "balena0")
 
@@ -477,6 +510,9 @@ func (s *DockerDaemonSuite) TestDaemonLogLevelWrong(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLogLevelDebug(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c, "--log-level=debug")
 	content, err := s.d.ReadLogFile()
 	c.Assert(err, checker.IsNil)
@@ -486,6 +522,9 @@ func (s *DockerDaemonSuite) TestDaemonLogLevelDebug(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLogLevelFatal(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// we creating new daemons to create new logFile
 	s.d.Start(c, "--log-level=fatal")
 	content, err := s.d.ReadLogFile()
@@ -496,6 +535,9 @@ func (s *DockerDaemonSuite) TestDaemonLogLevelFatal(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonFlagD(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c, "-D")
 	content, err := s.d.ReadLogFile()
 	c.Assert(err, checker.IsNil)
@@ -505,6 +547,9 @@ func (s *DockerDaemonSuite) TestDaemonFlagD(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonFlagDebug(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c, "--debug")
 	content, err := s.d.ReadLogFile()
 	c.Assert(err, checker.IsNil)
@@ -514,6 +559,9 @@ func (s *DockerDaemonSuite) TestDaemonFlagDebug(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonFlagDebugLogLevelFatal(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c, "--debug", "--log-level=fatal")
 	content, err := s.d.ReadLogFile()
 	c.Assert(err, checker.IsNil)
@@ -523,6 +571,9 @@ func (s *DockerDaemonSuite) TestDaemonFlagDebugLogLevelFatal(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonAllocatesListeningPort(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	listeningPorts := [][]string{
 		{"0.0.0.0", "0.0.0.0", "5678"},
 		{"127.0.0.1", "127.0.0.1", "1234"},
@@ -547,6 +598,9 @@ func (s *DockerDaemonSuite) TestDaemonAllocatesListeningPort(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonKeyGeneration(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// TODO: skip or update for Windows daemon
 	os.Remove("/etc/balena/key.json")
 	s.d.Start(c)
@@ -582,6 +636,9 @@ func (s *DockerDaemonSuite) TestDaemonExitOnFailure(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonBridgeExternal(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	d := s.d
 	err := d.StartWithError("--bridge", "nosuchbridge")
 	c.Assert(err, check.NotNil, check.Commentf("--bridge option with an invalid bridge should cause the daemon to fail"))
@@ -613,6 +670,9 @@ func (s *DockerDaemonSuite) TestDaemonBridgeExternal(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonBridgeNone(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// start with bridge none
 	d := s.d
 	d.StartWithBusybox(c, "--bridge", "none")
@@ -643,6 +703,9 @@ func deleteInterface(c *check.C, ifName string) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonBridgeIP(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// TestDaemonBridgeIP Steps
 	// 1. Delete the existing balena0 Bridge
 	// 2. Set --bip daemon configuration and start the new Docker Daemon
@@ -686,6 +749,9 @@ func (s *DockerDaemonSuite) TestDaemonBridgeIP(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithBridgeIPChange(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c)
 	defer s.d.Restart(c)
 	s.d.Stop(c)
@@ -706,6 +772,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithBridgeIPChange(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	d := s.d
 
 	bridgeName := "external-bridge"
@@ -729,6 +798,9 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr2(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	d := s.d
 
 	bridgeName := "external-bridge"
@@ -753,6 +825,9 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr2(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonBridgeFixedCIDREqualBridgeNetwork(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	d := s.d
 
 	bridgeName := "external-bridge"
@@ -771,6 +846,9 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCIDREqualBridgeNetwork(c *check
 }
 
 func (s *DockerDaemonSuite) TestDaemonDefaultGatewayIPv4Implicit(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	defaultNetworkBridge := "balena0"
 	deleteInterface(c, defaultNetworkBridge)
 
@@ -792,6 +870,9 @@ func (s *DockerDaemonSuite) TestDaemonDefaultGatewayIPv4Implicit(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonDefaultGatewayIPv4Explicit(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	defaultNetworkBridge := "balena0"
 	deleteInterface(c, defaultNetworkBridge)
 
@@ -814,6 +895,9 @@ func (s *DockerDaemonSuite) TestDaemonDefaultGatewayIPv4Explicit(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonDefaultGatewayIPv4ExplicitOutsideContainerSubnet(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	defaultNetworkBridge := "balena0"
 	deleteInterface(c, defaultNetworkBridge)
 
@@ -844,6 +928,9 @@ func (s *DockerDaemonSuite) TestDaemonDefaultNetworkInvalidClusterConfig(c *chec
 }
 
 func (s *DockerDaemonSuite) TestDaemonIP(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	d := s.d
 
 	ipStr := "192.170.1.1/24"
@@ -909,6 +996,9 @@ func (s *DockerDaemonSuite) TestDaemonICCPing(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonICCLinkExpose(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	d := s.d
 
 	bridgeName := "external-bridge"
@@ -935,6 +1025,9 @@ func (s *DockerDaemonSuite) TestDaemonICCLinkExpose(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLinksIpTablesRulesWhenLinkAndUnlink(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
 
@@ -970,6 +1063,9 @@ func (s *DockerDaemonSuite) TestDaemonLinksIpTablesRulesWhenLinkAndUnlink(c *che
 }
 
 func (s *DockerDaemonSuite) TestDaemonUlimitDefaults(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 
 	s.d.StartWithBusybox(c, "--default-ulimit", "nofile=42:42", "--default-ulimit", "nproc=1024:1024")
@@ -1018,6 +1114,9 @@ func (s *DockerDaemonSuite) TestDaemonUlimitDefaults(c *check.C) {
 
 // #11315
 func (s *DockerDaemonSuite) TestDaemonRestartRenameContainer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	if out, err := s.d.Cmd("run", "--name=test", "busybox"); err != nil {
@@ -1036,6 +1135,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartRenameContainer(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLoggingDriverDefault(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "--name=test", "busybox", "echo", "testline")
@@ -1074,6 +1176,9 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverDefault(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLoggingDriverDefaultOverride(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "--name=test", "--log-driver=none", "busybox", "echo", "testline")
@@ -1091,6 +1196,9 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverDefaultOverride(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLoggingDriverNone(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c, "--log-driver=none")
 
 	out, err := s.d.Cmd("run", "--name=test", "busybox", "echo", "testline")
@@ -1108,6 +1216,9 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverNone(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLoggingDriverNoneOverride(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c, "--log-driver=none")
 
 	out, err := s.d.Cmd("run", "--name=test", "--log-driver=json-file", "busybox", "echo", "testline")
@@ -1148,6 +1259,9 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverNoneOverride(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLoggingDriverNoneLogsError(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c, "--log-driver=none")
 
 	out, err := s.d.Cmd("run", "--name=test", "busybox", "echo", "testline")
@@ -1160,6 +1274,9 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverNoneLogsError(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLoggingDriverShouldBeIgnoredForBuild(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c, "--log-driver=splunk")
 
 	out, err := s.d.Cmd("build")
@@ -1173,6 +1290,9 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverShouldBeIgnoredForBuild(c *ch
 }
 
 func (s *DockerDaemonSuite) TestDaemonUnixSockCleanedUp(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	dir, err := ioutil.TempDir("", "socket-cleanup-test")
 	if err != nil {
 		c.Fatal(err)
@@ -1194,6 +1314,9 @@ func (s *DockerDaemonSuite) TestDaemonUnixSockCleanedUp(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonWithWrongkey(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	type Config struct {
 		Crv string `json:"crv"`
 		D   string `json:"d"`
@@ -1247,6 +1370,9 @@ func (s *DockerDaemonSuite) TestDaemonWithWrongkey(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartKillWait(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "-id", "busybox", "/bin/cat")
@@ -1281,6 +1407,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartKillWait(c *check.C) {
 
 // TestHTTPSInfo connects via two-way authenticated HTTPS to the info endpoint
 func (s *DockerDaemonSuite) TestHTTPSInfo(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	const (
 		testDaemonHTTPSAddr = "tcp://localhost:4271"
 	)
@@ -1309,6 +1438,9 @@ func (s *DockerDaemonSuite) TestHTTPSInfo(c *check.C) {
 // TestHTTPSRun connects via two-way authenticated HTTPS to the create, attach, start, and wait endpoints.
 // https://github.com/docker/docker/issues/19280
 func (s *DockerDaemonSuite) TestHTTPSRun(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	const (
 		testDaemonHTTPSAddr = "tcp://localhost:4271"
 	)
@@ -1344,6 +1476,9 @@ func (s *DockerDaemonSuite) TestTLSVerify(c *check.C) {
 // TestHTTPSInfoRogueCert connects via two-way authenticated HTTPS to the info endpoint
 // by using a rogue client certificate and checks that it fails with the expected error.
 func (s *DockerDaemonSuite) TestHTTPSInfoRogueCert(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	const (
 		errBadCertificate   = "bad certificate"
 		testDaemonHTTPSAddr = "tcp://localhost:4271"
@@ -1373,6 +1508,9 @@ func (s *DockerDaemonSuite) TestHTTPSInfoRogueCert(c *check.C) {
 // TestHTTPSInfoRogueServerCert connects via two-way authenticated HTTPS to the info endpoint
 // which provides a rogue server certificate and checks that it fails with the expected error
 func (s *DockerDaemonSuite) TestHTTPSInfoRogueServerCert(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	const (
 		errCaUnknown             = "x509: certificate signed by unknown authority"
 		testDaemonRogueHTTPSAddr = "tcp://localhost:4272"
@@ -1423,6 +1561,9 @@ func pingContainers(c *check.C, d *daemon.Daemon, expectFailure bool) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithSocketAsVolume(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	socket := filepath.Join(s.d.Folder, "balena.sock")
@@ -1435,6 +1576,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithSocketAsVolume(c *check.C) {
 // os.Kill should kill daemon ungracefully, leaving behind container mounts.
 // A subsequent daemon restart should clean up said mounts.
 func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonAndContainerKill(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
 		Experimental: testEnv.ExperimentalDaemon(),
 	})
@@ -1469,6 +1613,9 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonAndContainerKill(c *chec
 
 // os.Interrupt should perform a graceful daemon shutdown and hence cleanup mounts.
 func (s *DockerDaemonSuite) TestCleanupMountsAfterGracefulShutdown(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
 		Experimental: testEnv.ExperimentalDaemon(),
 	})
@@ -1491,6 +1638,9 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterGracefulShutdown(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRunContainerWithBridgeNone(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	s.d.StartWithBusybox(c, "-b", "none")
 
@@ -1519,6 +1669,9 @@ func (s *DockerDaemonSuite) TestRunContainerWithBridgeNone(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithContainerRunning(t *check.C) {
+
+	t.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(t)
 	if out, err := s.d.Cmd("run", "-d", "--name", "test", "busybox", "top"); err != nil {
 		t.Fatal(out, err)
@@ -1532,6 +1685,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithContainerRunning(t *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartCleanupNetns(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 	out, err := s.d.Cmd("run", "--name", "netns", "-d", "busybox", "top")
 	if err != nil {
@@ -1570,6 +1726,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartCleanupNetns(c *check.C) {
 
 // tests regression detailed in #13964 where DOCKER_TLS_VERIFY env is ignored
 func (s *DockerDaemonSuite) TestDaemonTLSVerifyIssue13964(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	host := "tcp://localhost:4271"
 	s.d.Start(c, "-H", host)
 	icmd.RunCmd(icmd.Cmd{
@@ -1593,6 +1752,9 @@ func teardownV6(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithContainerWithRestartPolicyAlways(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "-d", "--restart", "always", "busybox", "top")
@@ -1616,6 +1778,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithContainerWithRestartPolicyAlway
 }
 
 func (s *DockerDaemonSuite) TestDaemonWideLogConfig(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c, "--log-opt=max-size=1k")
 	name := "logtest"
 	out, err := s.d.Cmd("run", "-d", "--log-opt=max-file=5", "--name", name, "busybox", "top")
@@ -1632,6 +1797,9 @@ func (s *DockerDaemonSuite) TestDaemonWideLogConfig(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithPausedContainer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 	if out, err := s.d.Cmd("run", "-i", "-d", "--name", "test", "busybox", "top"); err != nil {
 		c.Fatal(err, out)
@@ -1665,6 +1833,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithPausedContainer(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartRmVolumeInUse(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("create", "-v", "test:/foo", "busybox")
@@ -1678,6 +1849,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartRmVolumeInUse(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartLocalVolumes(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c)
 
 	_, err := s.d.Cmd("volume", "create", "test")
@@ -1714,6 +1888,9 @@ func (s *DockerDaemonSuite) TestDaemonCorruptedFluentdAddress(c *check.C) {
 
 // FIXME(vdemeester) Use a new daemon instance instead of the Suite one
 func (s *DockerDaemonSuite) TestDaemonStartWithoutHost(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.UseDefaultHost = true
 	defer func() {
 		s.d.UseDefaultHost = false
@@ -1723,6 +1900,9 @@ func (s *DockerDaemonSuite) TestDaemonStartWithoutHost(c *check.C) {
 
 // FIXME(vdemeester) Use a new daemon instance instead of the Suite one
 func (s *DockerDaemonSuite) TestDaemonStartWithDefaultTLSHost(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.UseDefaultTLSHost = true
 	defer func() {
 		s.d.UseDefaultTLSHost = false
@@ -1782,6 +1962,9 @@ func (s *DockerDaemonSuite) TestDaemonStartWithDefaultTLSHost(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestBridgeIPIsExcludedFromAllocatorPool(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	defaultNetworkBridge := "balena0"
 	deleteInterface(c, defaultNetworkBridge)
 
@@ -1809,6 +1992,9 @@ func (s *DockerDaemonSuite) TestBridgeIPIsExcludedFromAllocatorPool(c *check.C) 
 
 // Test daemon for no space left on device error
 func (s *DockerDaemonSuite) TestDaemonNoSpaceLeftOnDeviceError(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux, Network)
 
 	testDir, err := ioutil.TempDir("", "no-space-left-on-device-test")
@@ -1841,6 +2027,9 @@ func (s *DockerDaemonSuite) TestDaemonNoSpaceLeftOnDeviceError(c *check.C) {
 
 // Test daemon restart with container links + auto restart
 func (s *DockerDaemonSuite) TestDaemonRestartContainerLinksRestart(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	parent1Args := []string{}
@@ -1899,6 +2088,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartContainerLinksRestart(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonCgroupParent(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 
 	cgroupParent := "test"
@@ -1926,6 +2118,9 @@ func (s *DockerDaemonSuite) TestDaemonCgroupParent(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithLinks(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux) // Windows does not support links
 	s.d.StartWithBusybox(c)
 
@@ -1949,6 +2144,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithLinks(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithNames(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux) // Windows does not support links
 	s.d.StartWithBusybox(c)
 
@@ -1996,6 +2194,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithNames(c *check.C) {
 
 // TestDaemonRestartWithKilledRunningContainer requires live restore of running containers
 func (s *DockerDaemonSuite) TestDaemonRestartWithKilledRunningContainer(t *check.C) {
+
+	t.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(t, DaemonIsLinux)
 	s.d.StartWithBusybox(t)
 
@@ -2046,6 +2247,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithKilledRunningContainer(t *check
 // The live containers should be known to the restarted daemon. Stopping
 // them now, should remove the mounts.
 func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonCrash(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 	s.d.StartWithBusybox(c, "--live-restore")
 
@@ -2085,6 +2289,9 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonCrash(c *check.C) {
 
 // TestDaemonRestartWithUnpausedRunningContainer requires live restore of running containers.
 func (s *DockerDaemonSuite) TestDaemonRestartWithUnpausedRunningContainer(t *check.C) {
+
+	t.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(t, DaemonIsLinux)
 	s.d.StartWithBusybox(t, "--live-restore")
 
@@ -2142,6 +2349,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithUnpausedRunningContainer(t *che
 // TestRunLinksChanged checks that creating a new container with the same name does not update links
 // this ensures that the old, pre gh#16032 functionality continues on
 func (s *DockerDaemonSuite) TestRunLinksChanged(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux) // Windows does not support links
 	s.d.StartWithBusybox(c)
 
@@ -2168,6 +2378,9 @@ func (s *DockerDaemonSuite) TestRunLinksChanged(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonStartWithoutColors(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 
 	infoLog := "\x1b[36mINFO\x1b"
@@ -2238,6 +2451,9 @@ func (s *DockerDaemonSuite) TestDaemonDebugLog(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonDiscoveryBackendConfigReload(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	// daemon config file
@@ -2295,6 +2511,9 @@ func (s *DockerDaemonSuite) TestDaemonLogOptions(c *check.C) {
 
 // Test case for #20936, #22443
 func (s *DockerDaemonSuite) TestDaemonMaxConcurrency(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c, "--max-concurrent-uploads=6", "--max-concurrent-downloads=8")
 
 	expectedMaxConcurrentUploads := `level=debug msg="Max Concurrent Uploads: 6"`
@@ -2307,6 +2526,9 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrency(c *check.C) {
 
 // Test case for #20936, #22443
 func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFile(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	// daemon config file
@@ -2348,6 +2570,9 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFile(c *check.C) {
 
 // Test case for #20936, #22443
 func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	// daemon config file
@@ -2405,6 +2630,9 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *chec
 }
 
 func (s *DockerDaemonSuite) TestBuildOnDisabledBridgeNetworkDaemon(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c, "-b=none", "--iptables=false")
 	out, code, err := s.d.BuildImageWithOut("busyboxs",
 		`FROM busybox
@@ -2416,6 +2644,9 @@ func (s *DockerDaemonSuite) TestBuildOnDisabledBridgeNetworkDaemon(c *check.C) {
 
 // Test case for #21976
 func (s *DockerDaemonSuite) TestDaemonDNSFlagsInHostMode(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	s.d.StartWithBusybox(c, "--dns", "1.2.3.4", "--dns-search", "example.com", "--dns-opt", "timeout:3")
@@ -2430,6 +2661,9 @@ func (s *DockerDaemonSuite) TestDaemonDNSFlagsInHostMode(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	conf, err := ioutil.TempFile("", "config-file-")
 	c.Assert(err, check.IsNil)
 	configName := conf.Name()
@@ -2548,6 +2782,9 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRunWithRuntimeFromCommandLine(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c, "--add-runtime", "oci=balena-runc", "--add-runtime", "vm=/usr/local/bin/vm-manager")
 
 	// Run with default runtime
@@ -2607,6 +2844,9 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromCommandLine(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithAutoRemoveContainer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	// top1 will exist after daemon restarts
@@ -2630,6 +2870,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithAutoRemoveContainer(c *check.C)
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartSaveContainerExitCode(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	containerName := "error-values"
@@ -2671,6 +2914,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartSaveContainerExitCode(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonBackcompatPre17Volumes(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon)
 	d := s.d
 	d.StartWithBusybox(c)
@@ -2749,6 +2995,9 @@ func (s *DockerDaemonSuite) TestDaemonBackcompatPre17Volumes(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonWithUserlandProxyPath(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	dockerProxyPath, err := exec.LookPath("balena-proxy")
@@ -2780,6 +3029,9 @@ func (s *DockerDaemonSuite) TestDaemonWithUserlandProxyPath(c *check.C) {
 
 // Test case for #22471
 func (s *DockerDaemonSuite) TestDaemonShutdownTimeout(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon)
 	s.d.StartWithBusybox(c, "--shutdown-timeout=3")
 
@@ -2801,6 +3053,9 @@ func (s *DockerDaemonSuite) TestDaemonShutdownTimeout(c *check.C) {
 
 // Test case for #22471
 func (s *DockerDaemonSuite) TestDaemonShutdownTimeoutWithConfigFile(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon)
 
 	// daemon config file
@@ -2835,6 +3090,9 @@ func (s *DockerDaemonSuite) TestDaemonShutdownTimeoutWithConfigFile(c *check.C) 
 
 // Test case for 29342
 func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 	s.d.StartWithBusybox(c, "--live-restore")
 
@@ -2863,6 +3121,9 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRemoveContainerAfterLiveRestore(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, overlayFSSupported, SameHostDaemon)
 	s.d.StartWithBusybox(c, "--live-restore", "--storage-driver", "overlay")
 	out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "top")
@@ -2896,6 +3157,9 @@ func (s *DockerDaemonSuite) TestRemoveContainerAfterLiveRestore(c *check.C) {
 
 // #29598
 func (s *DockerDaemonSuite) TestRestartPolicyWithLiveRestore(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	s.d.StartWithBusybox(c, "--live-restore")
 
@@ -2953,6 +3217,9 @@ func (s *DockerDaemonSuite) TestRestartPolicyWithLiveRestore(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestShmSize(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 
 	size := 67108864 * 2
@@ -2970,6 +3237,9 @@ func (s *DockerDaemonSuite) TestShmSize(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestShmSizeReload(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux)
 
 	configPath, err := ioutil.TempDir("", "test-daemon-shm-size-reload-config")
@@ -3029,6 +3299,9 @@ func testDaemonIpcPrivateShareable(d *daemon.Daemon, c *check.C, mustExist bool)
 
 // TestDaemonIpcModeShareable checks that --default-ipc-mode shareable works as intended.
 func (s *DockerDaemonSuite) TestDaemonIpcModeShareable(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 
 	s.d.StartWithBusybox(c, "--default-ipc-mode", "shareable")
@@ -3037,6 +3310,9 @@ func (s *DockerDaemonSuite) TestDaemonIpcModeShareable(c *check.C) {
 
 // TestDaemonIpcModePrivate checks that --default-ipc-mode private works as intended.
 func (s *DockerDaemonSuite) TestDaemonIpcModePrivate(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 
 	s.d.StartWithBusybox(c, "--default-ipc-mode", "private")
@@ -3060,12 +3336,18 @@ func testDaemonIpcFromConfig(s *DockerDaemonSuite, c *check.C, mode string, must
 
 // TestDaemonIpcModePrivateFromConfig checks that "default-ipc-mode: private" config works as intended.
 func (s *DockerDaemonSuite) TestDaemonIpcModePrivateFromConfig(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	testDaemonIpcFromConfig(s, c, "private", false)
 }
 
 // TestDaemonIpcModeShareableFromConfig checks that "default-ipc-mode: shareable" config works as intended.
 func (s *DockerDaemonSuite) TestDaemonIpcModeShareableFromConfig(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	testDaemonIpcFromConfig(s, c, "shareable", true)
 }
@@ -3108,6 +3390,9 @@ func testDaemonStartIpcMode(c *check.C, from, mode string, valid bool) {
 // arguments for default IPC mode, and bails out with incorrect ones.
 // Both CLI option (--default-ipc-mode) and config parameter are tested.
 func (s *DockerDaemonSuite) TestDaemonStartWithIpcModes(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 
 	ipcModes := []struct {
@@ -3133,6 +3418,9 @@ func (s *DockerDaemonSuite) TestDaemonStartWithIpcModes(c *check.C) {
 // (derived from daemon default) even after the daemon is restarted
 // with a different default ipc mode.
 func (s *DockerDaemonSuite) TestDaemonRestartIpcMode(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	f, err := ioutil.TempFile("", "test-daemon-ipc-config-restart")
 	c.Assert(err, checker.IsNil)
 	file := f.Name()
@@ -3173,6 +3461,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartIpcMode(c *check.C) {
 // TestFailedPluginRemove makes sure that a failed plugin remove does not block
 // the daemon from starting
 func (s *DockerDaemonSuite) TestFailedPluginRemove(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, IsAmd64, SameHostDaemon)
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{})
 	d.Start(c)

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -49,6 +49,9 @@ func (s *DockerSuite) TestEventsRedirectStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, swapMemorySupport)
 
 	errChan := make(chan error)
@@ -79,6 +82,9 @@ func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, NotArm, swapMemorySupport)
 
 	errChan := make(chan error)
@@ -388,6 +394,9 @@ func (s *DockerSuite) TestEventsFilterNetworkID(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	// daemon config file
@@ -457,6 +466,9 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	// daemon config file

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -83,6 +83,9 @@ func (s *DockerSuite) TestExecAfterContainerRestart(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestExecAfterDaemonRestart(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// TODO Windows CI: Requires a little work to get this ported.
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	s.d.StartWithBusybox(c)

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -296,6 +296,9 @@ func (s *DockerExternalVolumeSuite) TestVolumeCLICreateOptionConflict(c *check.C
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverNamed(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "--rm", "--name", "test-data", "-v", "external-volume-test:/tmp/external-volume-test", "--volume-driver", volumePluginName, "busybox:latest", "cat", "/tmp/external-volume-test/test")
@@ -318,6 +321,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverNamed(c *check.C) {
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverUnnamed(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "--rm", "--name", "test-data", "-v", "/tmp/external-volume-test", "--volume-driver", volumePluginName, "busybox:latest", "cat", "/tmp/external-volume-test/test")
@@ -332,6 +338,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverUnnamed(c *check.C) 
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverVolumesFrom(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "--name", "vol-test1", "-v", "/foo", "--volume-driver", volumePluginName, "busybox:latest")
@@ -351,6 +360,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverVolumesFrom(c *check
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverDeleteContainer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "--name", "vol-test1", "-v", "/foo", "--volume-driver", volumePluginName, "busybox:latest")
@@ -408,6 +420,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverLookupNotBlocked(c *
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverRetryNotImmediatelyExists(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 	driverName := "test-external-volume-driver-retry"
 
@@ -445,6 +460,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverRetryNotImmediatelyE
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverBindExternalVolume(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	dockerCmd(c, "volume", "create", "-d", volumePluginName, "foo")
 	dockerCmd(c, "run", "-d", "--name", "testing", "-v", "foo:/bar", "busybox", "top")
 
@@ -494,6 +512,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGet(c *check.C) {
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverWithDaemonRestart(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	dockerCmd(c, "volume", "create", "-d", volumePluginName, "abc1")
 	s.d.Restart(c)
 
@@ -507,6 +528,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverWithDaemonRestart(c 
 // Ensures that the daemon handles when the plugin responds to a `Get` request with a null volume and a null error.
 // Prior the daemon would panic in this scenario.
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGetEmptyResponse(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c)
 
 	out, err := s.d.Cmd("volume", "create", "-d", volumePluginName, "abc2", "--opt", "ninja=1")
@@ -519,6 +543,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGetEmptyResponse(c *
 
 // Ensure only cached paths are used in volume list to prevent N+1 calls to `VolumeDriver.Path`
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverPathCalls(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c)
 	c.Assert(s.ec.paths, checker.Equals, 0)
 
@@ -537,6 +564,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverPathCalls(c *check.C
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverMountID(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, err := s.d.Cmd("run", "--rm", "-v", "external-volume-test:/tmp/external-volume-test", "--volume-driver", volumePluginName, "busybox:latest", "cat", "/tmp/external-volume-test/test")
@@ -546,6 +576,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverMountID(c *check.C) 
 
 // Check that VolumeDriver.Capabilities gets called, and only called once
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverCapabilities(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.Start(c)
 	c.Assert(s.ec.caps, checker.Equals, 0)
 
@@ -560,6 +593,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverCapabilities(c *chec
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverOutOfBandDelete(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	driverName := stringid.GenerateNonCryptoID()
 	p := newVolumePlugin(c, driverName)
 	defer p.Close()
@@ -609,6 +645,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverOutOfBandDelete(c *c
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverUnmountOnMountFail(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 	s.d.Cmd("volume", "create", "-d", "test-external-volume-driver", "--opt=invalidOption=1", "--name=testumount")
 
@@ -619,6 +658,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverUnmountOnMountFail(c
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverUnmountOnCp(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 	s.d.Cmd("volume", "create", "-d", "test-external-volume-driver", "--name=test")
 

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -184,6 +184,9 @@ func (s *DockerSuite) TestInfoDisplaysStoppedContainers(c *check.C) {
 }
 
 func (s *DockerSuite) TestInfoDebug(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
@@ -204,6 +207,9 @@ func (s *DockerSuite) TestInfoDebug(c *check.C) {
 }
 
 func (s *DockerSuite) TestInsecureRegistries(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	registryCIDR := "192.168.1.0/24"
@@ -223,6 +229,9 @@ func (s *DockerSuite) TestInsecureRegistries(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRegistryMirrors(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	registryMirror1 := "https://192.168.1.2"

--- a/integration-cli/docker_cli_logout_test.go
+++ b/integration-cli/docker_cli_logout_test.go
@@ -14,6 +14,8 @@ import (
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithExternalAuth(c *check.C) {
 
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// @TODO TestLogoutWithExternalAuth expects docker to fall back to a v1 registry, so has to be updated for v17.12, when v1 registries are no longer supported
 	s.d.StartWithBusybox(c, "--disable-legacy-registry=false")
 

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -538,6 +538,9 @@ func (s *DockerSuite) TestDockerInspectNetworkWithContainerName(c *check.C) {
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectDisconnect(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	dockerCmd(c, "network", "create", "test")
 	assertNwIsAvailable(c, "test")
 	nr := getNwResource(c, "test")
@@ -808,6 +811,9 @@ func (s *DockerNetworkSuite) TestDockerPluginV2NetworkDriver(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDockerNetworkNoDiscoveryDefaultBridgeNetwork(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, ExecSupport)
 	// On default bridge network built-in service discovery should not happen
 	hostsFile := "/etc/hosts"
@@ -929,6 +935,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkAnonymousEndpoint(c *check.C) {
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkLinkOnDefaultNetworkOnly(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// Legacy Link feature must work only on default network, and not across networks
 	cnt1 := "container1"
 	cnt2 := "container2"
@@ -982,6 +991,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkOverlayPortMapping(c *check.C) {
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkDriverUngracefulRestart(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, NotUserNamespace, SameHostDaemon)
 	dnd := "dnd"
 	did := "did"
@@ -1089,6 +1101,9 @@ func verifyContainerIsConnectedToNetworks(c *check.C, d *daemon.Daemon, cName st
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkMultipleNetworksGracefulDaemonRestart(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon)
 	cName := "bb"
 	nwList := []string{"nw1", "nw2", "nw3"}
@@ -1108,6 +1123,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkMultipleNetworksGracefulDaemonRest
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkMultipleNetworksUngracefulDaemonRestart(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon)
 	cName := "cc"
 	nwList := []string{"nw1", "nw2", "nw3"}
@@ -1135,6 +1153,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkRunNetByID(c *check.C) {
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, NotUserNamespace, SameHostDaemon)
 	s.d.StartWithBusybox(c)
 
@@ -1161,6 +1182,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c 
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectToHostFromOtherNetwork(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
 	c.Assert(waitRun("container1"), check.IsNil)
 	dockerCmd(c, "network", "disconnect", "bridge", "container1")
@@ -1178,6 +1202,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkDisconnectFromHost(c *check.C) {
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectWithPortMapping(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, NotArm)
 	dockerCmd(c, "network", "create", "test1")
 	dockerCmd(c, "run", "-d", "--name", "c1", "-p", "5000:5000", "busybox", "top")
@@ -1195,6 +1222,9 @@ func verifyPortMap(c *check.C, container, port, originalMapping string, mustBeEq
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectDisconnectWithPortMapping(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// Connect and disconnect a container with explicit and non-explicit
 	// host port mapping to/from networks which do cause and do not cause
 	// the container default gateway to change, and verify docker port cmd
@@ -1232,6 +1262,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectDisconnectWithPortMapping(c
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectWithMac(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	macAddress := "02:42:ac:11:00:02"
 	dockerCmd(c, "network", "create", "mynetwork")
 	dockerCmd(c, "run", "--name=test", "-d", "--mac-address", macAddress, "busybox", "top")
@@ -1250,6 +1283,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkInspectCreatedContainer(c *check.C
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkRestartWithMultipleNetworks(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	dockerCmd(c, "network", "create", "test")
 	dockerCmd(c, "run", "--name=foo", "-d", "busybox", "top")
 	c.Assert(waitRun("foo"), checker.IsNil)
@@ -1261,6 +1297,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkRestartWithMultipleNetworks(c *che
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectDisconnectToStoppedContainer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon)
 	dockerCmd(c, "network", "create", "test")
 	dockerCmd(c, "create", "--name=foo", "busybox", "top")
@@ -1347,6 +1386,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectPreferredIP(c *check.C) {
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectPreferredIPStoppedContainer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// create a container
 	dockerCmd(c, "create", "--name", "c0", "busybox", "top")
 
@@ -1418,6 +1460,9 @@ func verifyIPAddresses(c *check.C, cName, nwname, ipv4, ipv6 string) {
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectLinkLocalIP(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// create one test network
 	dockerCmd(c, "network", "create", "--ipv6", "--subnet=2001:db8:1234::/64", "n0")
 	assertNwIsAvailable(c, "n0")
@@ -1594,6 +1639,9 @@ func (s *DockerSuite) TestUserDefinedNetworkConnectDisconnectAlias(c *check.C) {
 }
 
 func (s *DockerSuite) TestUserDefinedNetworkConnectivity(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	dockerCmd(c, "network", "create", "-d", "bridge", "br.net1")
 
@@ -1670,6 +1718,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkCreateDeleteSpecialCharacters(c *c
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartRestoreBridgeNetwork(t *check.C) {
+
+	t.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(t, DaemonIsLinux)
 	s.d.StartWithBusybox(t, "--live-restore")
 	defer s.d.Stop(t)

--- a/integration-cli/docker_cli_oom_killed_test.go
+++ b/integration-cli/docker_cli_oom_killed_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func (s *DockerSuite) TestInspectOomKilledTrue(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, memoryLimitSupport, swapMemorySupport)
 
 	name := "testoomkilled"
@@ -20,6 +23,9 @@ func (s *DockerSuite) TestInspectOomKilledTrue(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectOomKilledFalse(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, memoryLimitSupport, swapMemorySupport)
 
 	name := "testoomkilled"

--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -21,6 +21,9 @@ func (s *DockerSuite) TestCLIProxyDisableProxyUnixSock(c *check.C) {
 // Can't use localhost here since go has a special case to not use proxy if connecting to localhost
 // See https://golang.org/pkg/net/http/#ProxyFromEnvironment
 func (s *DockerDaemonSuite) TestCLIProxyProxyTCPSock(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon)
 	// get the IP to use to connect since we can't use localhost
 	addrs, err := net.InterfaceAddrs()

--- a/integration-cli/docker_cli_prune_unix_test.go
+++ b/integration-cli/docker_cli_prune_unix_test.go
@@ -77,6 +77,9 @@ func (s *DockerSwarmSuite) TestPruneNetwork(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestPruneImageDangling(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, _, err := s.d.BuildImageWithOut("test",
@@ -266,6 +269,9 @@ func (s *DockerSuite) TestPruneNetworkLabel(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestPruneImageLabel(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c)
 
 	out, _, err := s.d.BuildImageWithOut("test1",

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -260,6 +260,9 @@ func (s *DockerHubPullSuite) TestPullClientDisconnect(c *check.C) {
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestPullNoCredentialsNotFound(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// @TODO TestPullNoCredentialsNotFound expects docker to fall back to a v1 registry, so has to be updated for v17.12, when v1 registries are no longer supported
 	s.d.StartWithBusybox(c, "--disable-legacy-registry=false")
 

--- a/integration-cli/docker_cli_pull_trusted_test.go
+++ b/integration-cli/docker_cli_pull_trusted_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func (s *DockerTrustSuite) TestTrustedPull(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := s.setupTrustedImage(c, "trusted-pull")
 
 	// Try pull
@@ -23,6 +26,9 @@ func (s *DockerTrustSuite) TestTrustedPull(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedIsolatedPull(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := s.setupTrustedImage(c, "trusted-isolated-pull")
 
 	// Try pull (run from isolated directory without trust information)
@@ -46,6 +52,9 @@ func (s *DockerTrustSuite) TestUntrustedPull(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedPullFromBadTrustServer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := fmt.Sprintf("%v/dockerclievilpull/trusted:latest", privateRegistryURL)
 	evilLocalConfigDir, err := ioutil.TempDir("", "evil-local-config-dir")
 	if err != nil {
@@ -83,6 +92,9 @@ func (s *DockerTrustSuite) TestTrustedPullFromBadTrustServer(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedOfflinePull(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := s.setupTrustedImage(c, "trusted-offline-pull")
 
 	cli.Docker(cli.Args("pull", repoName), trustedCmdWithServer("https://invalidnotaryserver")).Assert(c, icmd.Expected{
@@ -133,6 +145,9 @@ func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, NotaryHosting)
 	repoName := fmt.Sprintf("%v/dockerclireleasesdelegationpulling/trusted", privateRegistryURL)
 	targetName := fmt.Sprintf("%s:latest", repoName)

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -282,6 +282,9 @@ func (s *DockerSchema1RegistrySuite) TestCrossRepositoryLayerPushNotSupported(c 
 }
 
 func (s *DockerTrustSuite) TestTrustedPush(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := fmt.Sprintf("%v/dockerclitrusted/pushtest:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
 	cli.DockerCmd(c, "tag", "busybox", repoName)
@@ -366,6 +369,9 @@ func (s *DockerTrustSuite) TestTrustedPushWithExistingSignedTag(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedPushWithIncorrectPassphraseForNonRoot(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	repoName := fmt.Sprintf("%v/dockercliincorretpwd/trusted:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
 	cli.DockerCmd(c, "tag", "busybox", repoName)

--- a/integration-cli/docker_cli_registry_user_agent_test.go
+++ b/integration-cli/docker_cli_registry_user_agent_test.go
@@ -71,6 +71,9 @@ func registerUserAgentHandler(reg *registry.Mock, result *string) {
 // a registry, the registry should see a User-Agent string of the form
 // [docker engine UA] UpstreamClientSTREAM-CLIENT([client UA])
 func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	var ua string
 
 	reg, err := registry.NewMock(c)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3033,6 +3033,9 @@ func (s *DockerSuite) TestRunPublishPort(c *check.C) {
 
 // Issue #10184.
 func (s *DockerSuite) TestDevicePermissions(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux)
 	const permissions = "crw-rw-rw-"
@@ -3182,6 +3185,9 @@ func (s *DockerSuite) TestRunNetworkFilesBindMountROFilesystem(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedRun(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// Windows does not support this functionality
 	testRequires(c, DaemonIsLinux)
 	repoName := s.setupTrustedImage(c, "trusted-run")
@@ -3211,6 +3217,9 @@ func (s *DockerTrustSuite) TestUntrustedRun(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedRunFromBadTrustServer(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	// Windows does not support this functionality
 	testRequires(c, DaemonIsLinux)
 	repoName := fmt.Sprintf("%v/dockerclievilrun/trusted:latest", privateRegistryURL)
@@ -3638,6 +3647,9 @@ func (s *DockerSuite) TestNetworkRmWithActiveContainers(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerRestartInMultipleNetworks(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, NotUserNamespace, NotArm)
 	// Create 2 networks using bridge driver
 	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
@@ -4216,6 +4228,9 @@ exec "$@"`,
 }
 
 func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	s.d.StartWithBusybox(c, "--debug", "--default-ulimit=nofile=65535")
 
 	name := "test-A"

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -240,6 +240,9 @@ func (s *DockerSuite) TestRunAttachDetachFromInvalidFlag(c *check.C) {
 
 // TestRunAttachDetachFromConfig checks attaching and detaching with the escape sequence specified via config file.
 func (s *DockerSuite) TestRunAttachDetachFromConfig(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	keyCtrlA := []byte{1}
 	keyA := []byte{97}
 
@@ -615,6 +618,9 @@ func (s *DockerSuite) TestRunWithInvalidPathforBlkioDeviceWriteIOps(c *check.C) 
 }
 
 func (s *DockerSuite) TestRunOOMExitCode(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, memoryLimitSupport, swapMemorySupport)
 	errChan := make(chan error)
 	go func() {
@@ -704,6 +710,9 @@ func (s *DockerSuite) TestRunWithMemoryReservationInvalid(c *check.C) {
 }
 
 func (s *DockerSuite) TestStopContainerSignal(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	out, _ := dockerCmd(c, "run", "--stop-signal", "SIGUSR1", "-d", "busybox", "/bin/sh", "-c", `trap 'echo "exit trapped"; exit 0' USR1; while true; do sleep 1; done`)
 	containerID := strings.TrimSpace(out)
 
@@ -1440,6 +1449,9 @@ func (s *DockerSuite) TestRunUserDeviceAllowed(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRunSeccompJSONNewFormat(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, seccompEnabled)
 
 	s.d.StartWithBusybox(c)
@@ -1465,6 +1477,9 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNewFormat(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRunSeccompJSONNoNameAndNames(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, seccompEnabled)
 
 	s.d.StartWithBusybox(c)
@@ -1491,6 +1506,9 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNoNameAndNames(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRunSeccompJSONNoArchAndArchMap(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, seccompEnabled)
 
 	s.d.StartWithBusybox(c)
@@ -1528,6 +1546,9 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNoArchAndArchMap(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRunWithDaemonDefaultSeccompProfile(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, SameHostDaemon, seccompEnabled)
 
 	s.d.StartWithBusybox(c)

--- a/integration-cli/docker_cli_userns_test.go
+++ b/integration-cli/docker_cli_userns_test.go
@@ -22,6 +22,9 @@ import (
 // 1. validate uid/gid maps are set properly
 // 2. verify that files created are owned by remapped root
 func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, SameHostDaemon, UserNamespaceInKernel)
 
 	s.d.StartWithBusybox(c, "--userns-remap", "default")

--- a/integration-cli/docker_cli_v2_only_test.go
+++ b/integration-cli/docker_cli_v2_only_test.go
@@ -25,6 +25,9 @@ func makefile(path string, contents string) (string, error) {
 // TestV2Only ensures that a daemon by default does not
 // attempt to contact any v1 registry endpoints.
 func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	reg, err := registry.NewMock(c)
 	defer reg.Close()
 	c.Assert(err, check.IsNil)
@@ -61,6 +64,9 @@ func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
 // and ensure v1 endpoints are hit for the following operations:
 // login, push, pull, build & run
 func (s *DockerRegistrySuite) TestV1(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	reg, err := registry.NewMock(c)
 	defer reg.Close()
 	c.Assert(err, check.IsNil)

--- a/integration-cli/docker_hub_pull_suite_test.go
+++ b/integration-cli/docker_hub_pull_suite_test.go
@@ -39,6 +39,9 @@ func newDockerHubPullSuite() *DockerHubPullSuite {
 
 // SetUpSuite starts the suite daemon.
 func (s *DockerHubPullSuite) SetUpSuite(c *check.C) {
+
+	c.Skip("Pending balenaEngine compatibility investigation")
+
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
 		Experimental: testEnv.ExperimentalDaemon(),

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestDaemonRestartKillContainers(t *testing.T) {
+
+	t.Skip("Pending balenaEngine compatibility investigation")
+
 	type testCase struct {
 		desc       string
 		config     *container.Config


### PR DESCRIPTION
Before this pull request, running `go` integration tests as per Dockerfile instructions (`hack/make.sh test-integration`) would result in ~1270 passed tests and ~180 failed tests. The failures appear to be caused by docker features that are intentionally not implemented by balenaEngine, but further detailed investigation is required. Skipping those tests for now allows one to verify their code changes against tests that are known to pass, thus providing us an immediate benefit.