### PR TITLE
Run vndr tool for balena-cli and balena-libnetwork (balenaEngine rename)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,7 @@ github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 
 #get libnetwork packages
-github.com/docker/libnetwork ab0835fffd654ce09b9e145d795c966ea2460eae https://github.com/resin-os/balena-libnetwork
+github.com/docker/libnetwork 2facb1986b84b2fcedf91dcbfdef72ab7aaf0667 https://github.com/resin-os/balena-libnetwork
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -63,7 +63,7 @@ github.com/pborman/uuid v1.0
 google.golang.org/grpc v1.3.0
 
 # When updating, also update RUNC_COMMIT in hack/dockerfile/binaries-commits accordingly
-github.com/opencontainers/runc 663abfe04156311a2683ae6f7e2e195dd81cd023 https://github.com/resin-os/balena-engine-runc
+github.com/opencontainers/runc 663abfe04156311a2683ae6f7e2e195dd81cd023 https://github.com/resin-os/balena-runc
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/image-spec v1.0.0
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
@@ -103,7 +103,7 @@ github.com/googleapis/gax-go da06d194a00e19ce00d9011a13931c3f6f6887c7
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 
 # containerd
-github.com/containerd/containerd 3325981309990c69cb2869a45709fbbf1afa2401 https://github.com/resin-os/balena-engine-containerd # v1.0.0
+github.com/containerd/containerd 3325981309990c69cb2869a45709fbbf1afa2401 https://github.com/resin-os/balena-containerd # v1.0.0
 github.com/containerd/btrfs 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244
 github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
 github.com/containerd/continuity 35d55c5e8dd23b32037d56cf97174aff3efdfa83
@@ -143,7 +143,7 @@ github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.com/ijc25/Gotty
 
 # docker CLI
-github.com/docker/cli 8d84dffd5547772e1f110e9e735c13af262d4ee5 https://github.com/resin-os/balena-cli
+github.com/docker/cli ce80489d66dfc63ac005f55f5bdca2f03abee6e9 https://github.com/resin-os/balena-cli
 github.com/mitchellh/mapstructure f3009df150dadf309fdee4a54ed65c124afad715
 gopkg.in/yaml.v2 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
 github.com/docker/docker-credential-helpers 3c90bd29a46b943b2a9842987b58fb91a7c1819b

--- a/vendor/github.com/containerd/containerd/plugin/plugin_go18.go
+++ b/vendor/github.com/containerd/containerd/plugin/plugin_go18.go
@@ -3,6 +3,6 @@
 package plugin
 
 func loadPlugins(path string) error {
-	// no plugin support to avoid binary size costs in balena-engine
+	// no plugin support to avoid binary size costs in balena
 	return nil
 }


### PR DESCRIPTION
Note: the result of running the `vndr` tool did not result in additional changes under this pull request because most of the renaming changes had already been merged when incorrectly "manually" updating the contents of the vendor folder (not using the `vndr` tool) in a previous renaming pull request.